### PR TITLE
There should be really only one write to a Chanel when there is one reader.

### DIFF
--- a/confirm.go
+++ b/confirm.go
@@ -22,7 +22,7 @@ func NewUpgradeConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 		var cancel func()
 		var d dialog.Dialog
 
-		var timeouted int32
+		var timedout int32
 
 		resp := make(chan bool)
 		if timeout > 0 {
@@ -30,18 +30,18 @@ func NewUpgradeConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 			cancel = fn
 			go func() {
 				<-ctx.Done()
-				atomic.StoreInt32(&timeouted, 1)
+				atomic.StoreInt32(&timedout, 1)
 				d.Hide()
 			}()
 		}
 		d = dialog.NewConfirm("Application Update", info+"\n\nDo you wish to update?\n", func(ok bool) {
-			if cancel != nil {
-				cancel()
-			}
-			if atomic.LoadInt32(&timeouted) == 1 {
+			if atomic.LoadInt32(&timedout) == 1 {
 				ok = true
 			}
 			resp <- ok
+			if cancel != nil {
+				cancel()
+			}
 		}, win)
 
 		d.Show()
@@ -62,7 +62,7 @@ func NewRestartConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 		var cancel func()
 		var d dialog.Dialog
 
-		var timeouted int32
+		var timedout int32
 
 		resp := make(chan bool)
 		if timeout > 0 {
@@ -70,18 +70,18 @@ func NewRestartConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 			cancel = fn
 			go func() {
 				<-ctx.Done()
-				atomic.StoreInt32(&timeouted, 1)
+				atomic.StoreInt32(&timedout, 1)
 				d.Hide()
 			}()
 		}
 		d = dialog.NewConfirm("Application Update", "The application was updated.\nDo you wish to restart it?\n", func(ok bool) {
-			if cancel != nil {
-				cancel()
-			}
-			if atomic.LoadInt32(&timeouted) == 1 {
+			if atomic.LoadInt32(&timedout) == 1 {
 				ok = true
 			}
 			resp <- ok
+			if cancel != nil {
+				cancel()
+			}
 		}, win)
 
 		d.Show()


### PR DESCRIPTION
Calling Hide will trigger the dialog callback which might send a false
value before the timeout code send a true value. Resulting in a
default-to-no behavior instead of the intended default-to-yes.