### PR TITLE
Add localization support via fyne.io/fyne/v2/lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,45 @@ func NewProgressCallback(win fyne.Window)
 func NewExitCallback(app fyne.App, win fyne.Window)
 ```
 
+## Localization
+
+`fyneselfupdate` uses Fyne's standard [`lang`](https://docs.fyne.io/api/v2/lang/pkg/) package to
+translate the text shown in its dialogs (update confirmation, restart confirmation and the
+download progress window). No text is hardcoded to English only, everything goes through
+`lang.L`, so it will follow whatever locale your application has configured.
+
+Ready-made translation bundles for `fyneselfupdate`'s own strings are provided in the
+[`translations`](./translations) folder, named `fyneselfupdate.<lang>.json` (for example
+`fyneselfupdate.de.json`). Copy the ones you need into your own application and load them
+alongside your own translations:
+
+```go
+//go:embed translations/*.json
+var translationsFS embed.FS
+
+func main() {
+	a := app.New()
+	w := a.NewWindow("My App")
+
+	// Load fyneselfupdate's translations together with your own app's translations.
+	if err := lang.AddTranslationsFS(translationsFS, "translations"); err != nil {
+		log.Println("Failed to load translations:", err)
+	}
+
+	...
+}
+```
+
+The `<prefix>.` in the file name avoids collisions if your own application already has a
+`de.json`, `fr.json`, etc. in the same `translations` folder, just keep both files side by side.
+
+If a translation for the current locale is missing, `fyneselfupdate` falls back to the original
+English text, so adding localization support is entirely optional and backward compatible.
+
+Contributions of new language bundles for `fyneselfupdate` are welcome - please open a pull
+request adding a `fyneselfupdate.<lang>.json` file under `translations/`.
+
+
 ## API Compatibility Promises
 The main branch of `fyneselfupdate` is *not* guaranteed to have a stable API over time. Still we will try hard to not break its API unecessarily and will follow a proper versioning of our release. We will also keep it in sync and up to date with `fynelabs/selfupate`.
 

--- a/confirm.go
+++ b/confirm.go
@@ -6,6 +6,7 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/lang"
 	"golang.org/x/net/context"
 )
 
@@ -34,7 +35,11 @@ func NewUpgradeConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 				d.Hide()
 			}()
 		}
-		d = dialog.NewConfirm("Application Update", info+"\n\nDo you wish to update?\n", func(ok bool) {
+		// info comes from the selfupdate package (e.g. "New version found) and is looked
+		// up as its own translation key via lang.L, with itself as fallback if no
+		// translation is found
+		message := lang.L(info) + "\n\n" + lang.L("Do you wish to update?") + "\n"
+		d = dialog.NewConfirm(lang.L("Application Update"), message, func(ok bool) {
 			if atomic.LoadInt32(&timedout) == 1 {
 				ok = true
 			}
@@ -74,7 +79,11 @@ func NewRestartConfirmCallbackWithTimeout(win fyne.Window, timeout time.Duration
 				d.Hide()
 			}()
 		}
-		d = dialog.NewConfirm("Application Update", "The application was updated.\nDo you wish to restart it?\n", func(ok bool) {
+
+		message := lang.L("The application was updated.") + "\n" +
+			lang.L("Do you wish to restart it?") + "\n"
+
+		d = dialog.NewConfirm(lang.L("Application Update"),message, func(ok bool) {
 			if atomic.LoadInt32(&timedout) == 1 {
 				ok = true
 			}

--- a/progress.go
+++ b/progress.go
@@ -4,6 +4,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/lang"
 	"fyne.io/fyne/v2/widget"
 )
 
@@ -20,8 +21,8 @@ func NewProgressCallback(win fyne.Window) func(float64, error) {
 			} else {
 				progress = widget.NewProgressBar()
 			}
-			content := container.NewVBox(widget.NewLabel("Downloading update"), progress)
-			d = dialog.NewCustomWithoutButtons("Application update", content, win)
+			content := container.NewVBox(widget.NewLabel(lang.L("Downloading update")), progress)
+			d = dialog.NewCustomWithoutButtons(lang.L("Application update"), content, win)
 			fyne.Do(d.Show)
 		}
 

--- a/translations/fyneselfupdate.de.json
+++ b/translations/fyneselfupdate.de.json
@@ -1,0 +1,8 @@
+{
+  "New version found": "Neue Version gefunden",
+  "Do you wish to update?": "Möchten Sie aktualisieren?",
+  "Application Update": "Anwendungsaktualisierung",
+  "The application was updated.": "Die Anwendung wurde aktualisiert.",
+  "Do you wish to restart it?": "Möchten Sie sie neu starten?",
+  "Downloading update": "Update wird heruntergeladen"
+}


### PR DESCRIPTION
Adds support for Fyne's standard localization package (lang) to fyneselfupdate. All strings shown in the update/restart confirmation dialogs and the download progress dialog are now passed through lang.L(...), so they will be translated if the consuming application provides a matching translation bundle and simply fall back to English otherwise.

No breaking changes to the public API. Behavior is unchanged for applications that don't call lang.AddTranslations* dialogs still show the same English text as before (used as the fallback).